### PR TITLE
Tweak some details in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ This project contains the runner script `fmiprecice` to couple FMU models with o
 * Python 3 or higher
 * [preCICE](https://precice.org/installation-overview.html), v2
 * [pyprecice: Python language bindings for preCICE](https://github.com/precice/python-bindings)
-* [numpy](https://numpy.org/install/)
-* [fmpy](https://fmpy.readthedocs.io/en/latest/install/)
+* [NumPy](https://numpy.org/install/)
+* [FMPy](https://fmpy.readthedocs.io/en/latest/install/)
 
 ## Installation 
 
@@ -24,7 +24,7 @@ To use **pip** for the installation, run the command:
 pip3 install --user -e .
 ```
 
-The editable flag `-e` allows you to update the preICE-FMI Runner by pulling the repository.
+The editable flag `-e` allows you to update the preCICE-FMI Runner by pulling the repository.
 
 To use **Python** for the installation, run the command:
 

--- a/README.md
+++ b/README.md
@@ -2,21 +2,21 @@
 
 The [Functional Mock-Up Interface](https://fmi-standard.org/) (FMI) is a standard for the exchange of dynamic simulation models. Currently, it is the de-facto industry standard for co-simulation. The models implementing the FMI standard are called Functional Mock-Up Units (FMU).
 
-This project aims to couple FMU models with other simulation tools with the coupling library [preCICE](https://precice.org/). To this end, a preCICE-FMI Runner is being developed (see image). The Runner serves as an importer for the FMU to steer the simulation. Additionally, it calls the preCICE library to communicate and coordinate with other solvers. 
+This project contains the runner script `fmiprecice` to couple FMU models with other simulation tools via the coupling library [preCICE](https://precice.org/). The runner serves as an importer for the FMU to steer the simulation. Additionally, it calls the preCICE library to communicate and coordinate with other solvers. 
 
 ![img](images/precice-fmi-runner-setup.png)
 
 ## Dependencies
 
 * Python 3 or higher
-* [preCICE](https://github.com/precice/precice/wiki)
+* [preCICE](https://precice.org/installation-overview.html), v2
 * [pyprecice: Python language bindings for preCICE](https://github.com/precice/python-bindings)
 * [numpy](https://numpy.org/install/)
 * [fmpy](https://fmpy.readthedocs.io/en/latest/install/)
 
 ## Installation 
 
-First, clone this repository and open a terminal in the `fmi-runner` directory.
+Clone this repository and open a terminal in the root directory.
 
 To use **pip** for the installation, run the command:
 
@@ -24,7 +24,7 @@ To use **pip** for the installation, run the command:
 pip3 install --user -e .
 ```
 
-The editable flag `-e` allows you to update the Runner by simply pulling the repository.
+The editable flag `-e` allows you to update the preICE-FMI Runner by pulling the repository.
 
 To use **Python** for the installation, run the command:
 
@@ -40,7 +40,7 @@ The Runner is called from the terminal with the command `fmiprecice`. It takes t
 fmiprecice ./fmi-settings.json ./precice-settings.json
 ```
 
-You can find more information about the Runner, its abilities and limitations in [1]. The preCICE [Oscillator tutorial](https://precice.org/tutorials-oscillator.html) will feature a first complete setup with FMU model and setting files soon. 
+You can find more information about the runner, its abilities, and its limitations in [1]. The [oscillator tutorial](https://precice.org/tutorials-oscillator.html) will feature a first complete setup with FMU model and setting files soon. 
 
 ## References
 


### PR DESCRIPTION
Wording:
- The name of the software is preCICE-FMI Runner.
- The name of the executable is `fmiprecice`.
- If we only talk about the executable, let's use "the executable", "the script", or "the runner". Not "the Runner".

Please specify which version of FMPy is required, or which ones you used / tested.