### PR TITLE
Restrict versions of fmpy and numpy requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name="fmiprecice"
 dynamic = [ "version" ]
 dependencies = [
-    "fmpy", "numpy", "pyprecice>=3.0"
+    "fmpy >=0.3.13, <=0.3.20", "numpy >1, <2", "pyprecice>=3.0"
 ]
 requires-python = ">=3.8"
 authors = [


### PR DESCRIPTION
Restricts the NumPy version to 1 and fmpy version to one of the versions documented in https://github.com/precice/fmi-runner/blob/main/docs/README.md, since fmpy now uses NumPy 2.

Still testing.